### PR TITLE
Fix SQL query failure by escaping reserved keyword "end" for PostgreSQL compatibility

### DIFF
--- a/app/Livewire/Dashboard/TimeNow.php
+++ b/app/Livewire/Dashboard/TimeNow.php
@@ -17,7 +17,7 @@ class TimeNow extends Component
         return view('livewire.dashboard.time-now', [
             'latest_work' => TimeEntry::with(['client', 'work_type'])
                 ->select('time_entries.*')
-                ->join(DB::raw('(SELECT MAX(id) as max_id FROM time_entries WHERE end IS NOT NULL GROUP BY project_id) as sub'), function ($join) {
+                ->join(DB::raw('(SELECT MAX(id) as max_id FROM time_entries WHERE "end" IS NOT NULL GROUP BY project_id) as sub'), function ($join) {
                     $join->on('time_entries.id', '=', 'sub.max_id');
                 })
                 ->orderBy('time_entries.created_at', 'desc')


### PR DESCRIPTION
# Description
I encountered an issue when switching from MySQL to PostgreSQL, where loading the dashboard failed due to the use of the unescaped column name "end" in a raw SQL query. The word end is a reserved keyword in PostgreSQL ([see here](https://www.postgresql.org/docs/current/sql-keywords-appendix.html)), and as a result, the query produced syntax errors in PostgreSQL environments. In MySQL, "end" is a keyword, but not reserved ([see here](https://dev.mysql.com/doc/refman/8.4/en/keywords.html)).

This PR resolves the issue by properly escaping the "end" column name with double quotes ("end") to ensure compatibility with PostgreSQL.

# Testing
* Tested in a PostgreSQL environment, where the query now executes successfully after the fix
* No regressions observed in MySQL after testing the change
