### PR TITLE
Fix config caching issue for APP_ALLOW_REGISTER in Laravel Octane

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'allow_registration' => env('APP_ALLOW_REGISTER', true),
+];

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -12,7 +12,7 @@ use App\Http\Controllers\Auth\VerifyEmailController;
 use Illuminate\Support\Facades\Route;
 
 Route::middleware('guest')->group(function () {
-    if (env('APP_ALLOW_REGISTER', true)) {
+    if (config('app.allow_registration')) {
         Route::get('register', [RegisteredUserController::class, 'create'])
             ->name('register');
 


### PR DESCRIPTION
### Description
This PR addresses an issue where env() was used directly in the route file instead of config(). This caused problems when the configuration was cached, such as when using Laravel Octane, resulting in the application always returning the default value for APP_ALLOW_REGISTER. By replacing env() with config(), this ensures proper behavior when cached configurations are used, allowing the application to correctly determine if registration routes should be available.

### Changes
* Added an `config/app.php` file, handling the APP_ALLOW_REGISTER env variable
* Replaced env() with config() in the `auth.php` route file

### Concerns
Prior to this PR, the `config/app.php` file was not present, which is unusual since it typically contains default settings for a Laravel application. If there was a specific reason for omitting this file, I recommend we consider moving the allow_registration configuration to a different configuration file. Please feel free to provide feedback or adjust the placement as needed.